### PR TITLE
Patched Fix word-wrap vulnerable to Regular Expression Denial of Service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2216,8 +2216,9 @@
 			}
 		},
 		"node_modules/word-wrap": {
-			"version": "1.2.3",
-			"license": "MIT",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3538,7 +3539,9 @@
 			}
 		},
 		"word-wrap": {
-			"version": "1.2.3"
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
 		},
 		"wrappy": {
 			"version": "1.0.2"


### PR DESCRIPTION
Affected of this project are vulnerable to Regular Expression Denial of Service (ReDoS) due to the usage of an insecure regular expression within the result variable.

The regex is vulnerable on its own, but the vulnerable function is not reachable as shipped in the package.
```js
const wrap = require("word-wrap"); for (let i = 0; i <= 10; i++) { const attack = "a" + "t".repeat(i * 10_00000); const start = performance.now(); wrap( attack, { trim: true }, ); console.log(`${attack.length} characters: ${performance.now() - start}ms`); }
```
Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.


## Impact
CWE-1333
CVE-2023-26115
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L`